### PR TITLE
Handle migration from localStorage to chrome.storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,6 @@
   "permissions": [
     "storage",
     "tabs",
-    "activeTab",
     "scripting"
   ],
   "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "URLColors",
   "short_name": "URLColors",
   "description": "A chrome extension that adds a colored border around websites that match user inputted preferences.",
-  "version": "2",
+  "version": "2.1",
   "manifest_version": 3,
   "host_permissions": ["https://*/*"],
   "permissions": [


### PR DESCRIPTION
1) Adds this badge for users updating from a manifest V2 version.  They need to open the popup for the migration to be completed since the service worker does not have access to localStorage which is where the previous settings live.
<img width="47" alt="image" src="https://github.com/fej-snikduj/URLColors/assets/20237437/5d3302c7-7870-4dfd-b503-1c007a8dc52e">

2) Once the popup is opened, the migration happens instantly for anyone that has `urlColorPrefs` in localStorage, which indicates they have used a manifest V2 of the extension and have not yet migrated (this is the first time opening the manifest V3 modal).  We move values from localStorage to chrome.storage.  We delete all localStorage.  And then we change the badge icon to indicate a success:
<img width="56" alt="image" src="https://github.com/fej-snikduj/URLColors/assets/20237437/2f1c45d1-03f6-435b-8f42-32baa79b1e7e">

3) the green badge icon remains on the extension icon until the next time they open it at which point it goes away

I wanted the green badge to go away when the popup is closed, but there is no way for the serviceWorker to know it closed.  I tried sending a message to the serivceWorker from the popup's `beforeunloaded` event listener but didn't run into any luck.  This solution isn't terrible.