### PR TITLE
fix: superposition in corners

### DIFF
--- a/urlColorsContentScript.js
+++ b/urlColorsContentScript.js
@@ -45,8 +45,8 @@ const addNewDivs = (color, flash, timer, borderWidth, opacity) => {
   });
 
   vertical.forEach((div) => {
-    div.style.top = '0';
-    div.style.bottom = '0';
+    div.style.top = borderWidth;
+    div.style.bottom = borderWidth;
     div.style.width = borderWidth;
   });
 


### PR DESCRIPTION
Fix superposition for all corners when the frame blinks or when transparency is set.

![image](https://github.com/user-attachments/assets/7bcf0986-76fe-4657-9f9e-9623dcc6fb86) :arrow_right: ![image](https://github.com/user-attachments/assets/2f293928-433c-485f-b31a-9e75120c96f3)

